### PR TITLE
Strip guess of leading and trailing spaces

### DIFF
--- a/handlers/game.py
+++ b/handlers/game.py
@@ -317,8 +317,8 @@ def guess(update: Update, context: CallbackContext):
             return
         else:
             # if the exclamation setting is activated, only messages starting with an ! are valid
-            # lets remove the !
-            word = word[1:]
+            # lets remove the ! and a potential following space
+            word = word[1:].strip()
     else:
         # if the exclamation setting is activated, only messages starting with an ! are valid
         if chat_data["exclamation"]:


### PR DESCRIPTION
Most phone keyboards auto-insert a space so if you guess "!word" it writes "! word"
Fix this by stripping leading and trailing spaces.